### PR TITLE
fix incompatibility with pools lib by providing a default idle timeout

### DIFF
--- a/crypto11.go
+++ b/crypto11.go
@@ -241,6 +241,10 @@ type Config struct {
 
 	// Maximum time to wait for a session from the sessions pool. Zero means wait indefinitely.
 	PoolWaitTimeout time.Duration
+
+	// Maximum time to allow for a session to be unused before replacing it with a new one in the pool.
+	// Zero means there is no timeout. Zero is the default.
+	PoolIdleTimeout time.Duration
 }
 
 // refCount counts the number of contexts using a particular P11 library. It must not be read or modified
@@ -314,7 +318,7 @@ func Configure(config *Config) (*Context, error) {
 	}
 
 	// We will use one session to keep state alive, so the pool gets maxSessions - 1
-	instance.pool = pools.NewResourcePool(instance.resourcePoolFactoryFunc, maxSessions-1, maxSessions-1, 0)
+	instance.pool = pools.NewResourcePool(instance.resourcePoolFactoryFunc, maxSessions-1, maxSessions-1, config.PoolIdleTimeout, 0)
 
 	// Create a long-term session and log it in. This session won't be used by callers, instead it is used to keep
 	// a connection alive to the token to ensure object handles and the log in status remain accessible.


### PR DESCRIPTION
There is an error when using this lib with a more recent version of the vitessio pools library:
```
../../crypto11/crypto11.go:317:39: not enough arguments in call to pools.NewResourcePool
        have (func() (pools.Resource, error), int, int, number)
        want (pools.Factory, int, int, time.Duration, int)
```

I set this value to 0 by default by adding a new field to the Config struct.